### PR TITLE
Add basic m3u8 playlist file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ git_branch = $(shell git rev-parse --abbrev-ref HEAD)
 git_hash = $(shell git rev-parse --short HEAD)
 
 zip_name = $(name)-$(version)-$(git_hash).zip
-include_files = addon.py addon.xml channels.py LICENSE README.md resources/
+include_files = addon.py addon.xml channels.py LICENSE README.md resources/ vrt.m3u8
 include_paths = $(patsubst %,$(name)/%,$(include_files))
 exclude_files = \*.new \*.orig \*.pyc
 zip_dir = $(name)/

--- a/vrt.m3u8
+++ b/vrt.m3u8
@@ -1,0 +1,87 @@
+#EXTM3U
+#EXTINF:-1 tvg-id="een" tvg-logo="https://images.vrt.be/height100/logo/een/een_LOGO_zwart.png" tvg-name="Eén",Eén
+plugin://plugin.video.vrt.nu/play/id/vualto_een_geo?ext=.pvr
+
+#EXTINF:-1 tvg-id="canvas" tvg-logo="https://images.vrt.be/height100/logo/canvas/CANVAS_logo_lichtblauw.jpg" tvg-name="Canvas",Canvas
+plugin://plugin.video.vrt.nu/play/id/vualto_canvas_geo?ext=.pvr
+
+#EXTINF:-1 tvg-id="ketnet" tvg-logo="https://images.vrt.be/height100/logo/ketnet/ketnet_LOGO_rood_geel.png" tvg-name="Ketnet",Ketnet
+plugin://plugin.video.vrt.nu/play/id/vualto_ketnet_geo?ext=.pvr
+
+#EXTINF:-1 tvg-id="ketnetjr" tvg-logo="https://images.vrt.be/height100/logo/ketnet/ketnet_LOGO_rood_geel.png" tvg-name="Ketnet Junior",Ketnet Junior
+plugin://plugin.video.vrt.nu/play/id/ketnet_jr?ext=.pvr
+
+#EXTINF:-1 tvg-id="sporza" tvg-logo="https://images.vrt.be/height100/logo/sporza/sporza_logo_zwart.png" tvg-name="Sporza",Sporza
+plugin://plugin.video.vrt.nu/play/id/vualto_sporza_geo?ext=.pvr
+
+#EXTINF:-1 tvg-id="vrtnws" tvg-logo="https://images.vrt.be/height100/logos/vrtnws.png" tvg-name="VRT NWS",VRT NWS
+plugin://plugin.video.vrt.nu/play/id/vualto_nieuws?ext=.pvr
+
+#EXTINF:-1 tvg-id="radio1tv" tvg-logo="https://images.vrt.be/height100/logos/radio1.png" tvg-name="Radio 1",Radio 1
+plugin://plugin.video.vrt.nu/play/id/vualto_radio1?ext=.pvr
+
+#EXTINF:-1 tvg-id="radio2tv" tvg-logo="https://images.vrt.be/height100/logo/radio2/RADIO2_RED_RGB.png" tvg-name="Radio 2",Radio 2
+plugin://plugin.video.vrt.nu/play/id/vualto_radio2?ext=.pvr
+
+#EXTINF:-1 tvg-id="klaratv" tvg-logo="https://images.vrt.be/height100/logos/klara.png" tvg-name="Klara",Klara
+plugin://plugin.video.vrt.nu/play/id/vualto_klara?ext=.pvr
+
+#EXTINF:-1 tvg-id="stubrutv" tvg-logo="https://images.vrt.be/orig/2019/03/12/1e383cf5-44a7-11e9-abcc-02b7b76bf47f.png" tvg-name="Studio Brussel",Studio Brussel
+plugin://plugin.video.vrt.nu/play/id/vualto_stubru?ext=.pvr
+
+#EXTINF:-1 tvg-id="mnm" tvg-logo="https://images.vrt.be/height100/logo/mnm/logo_witte_achtergrond.png" tvg-name="MNM",MNM
+plugin://plugin.video.vrt.nu/play/id/vualto_mnm?ext=.pvr
+
+#EXTINF:-1 tvg-id="vrt-events1" tvg-logo="https://images.vrt.be/orig/logo/vrt.png" tvg-name="VRT Events 1",VRT Events 1
+plugin://plugin.video.vrt.nu/play/id/vualto_events1_geo?ext=.pvr
+
+#EXTINF:-1 tvg-id="vrt-events2" tvg-logo="https://images.vrt.be/orig/logo/vrt.png" tvg-name="VRT Events 2",VRT Events 2
+plugin://plugin.video.vrt.nu/play/id/vualto_events2_geo?ext=.pvr
+
+#EXTINF:-1 tvg-id="vrt-events3" tvg-logo="https://images.vrt.be/orig/logo/vrt.png" tvg-name="VRT Events 3",VRT Events 3
+plugin://plugin.video.vrt.nu/play/id/vualto_events3_geo?ext=.pvr
+
+#EXTINF:-1 radio="true" tvg-id="radio1" tvg-logo="https://images.vrt.be/height100/logos/radio1.png" tvg-name="Radio 1",Radio 1
+http://icecast.vrtcdn.be/radio1-high.mp3?ext=.pvr
+
+#EXTINF:-1 radio="true" tvg-id="radio1-classics" tvg-logo="https://images.vrt.be/height100/2020/04/08/b1c35b45-7961-11ea-aae0-02b7b76bf47f.png" tvg-name="Radio 1 Classics",Radio 1 Classics
+http://icecast.vrtcdn.be/radio1_classics_high.mp3?ext=.pvr
+
+#EXTINF:-1 radio="true" tvg-id="radio2" tvg-logo="https://images.vrt.be/height100/logo/radio2/RADIO2_RED_RGB.png" tvg-name="Radio 2",Radio 2
+http://icecast.vrtcdn.be/ra2ovl-high.mp3?ext=.pvr
+
+#EXTINF:-1 radio="true" tvg-id="klara" tvg-logo="https://images.vrt.be/height100/logos/klara.png" tvg-name="Klara",Klara
+http://icecast.vrtcdn.be/klara-high.mp3?ext=.pvr
+
+#EXTINF:-1 radio="true" tvg-id="klara-continuo" tvg-logo="https://images.vrt.be/height100/logos/klara_continuo.png" tvg-name="Klara Continuo",Klara Continuo
+http://icecast.vrtcdn.be/klaracontinuo-high.mp3?ext=.pvr
+
+#EXTINF:-1 radio="true" tvg-id="stubru" tvg-logo="https://images.vrt.be/orig/2019/03/12/1e383cf5-44a7-11e9-abcc-02b7b76bf47f.png" tvg-name="Studio Brussel",Studio Brussel
+http://icecast.vrtcdn.be/stubru-high.mp3?ext=.pvr
+
+#EXTINF:-1 radio="true" tvg-id="stubru-tijdloze" tvg-logo="https://images.vrt.be/height100/2019/02/21/923b0fe2-35ce-11e9-abcc-02b7b76bf47f.png" tvg-name="StuBru De Tijdloze",StuBru De Tijdloze
+http://icecast.vrtcdn.be/stubru_tijdloze-high.mp3?ext=.pvr
+
+#EXTINF:-1 radio="true" tvg-id="stubru-tgs" tvg-logo="https://images.vrt.be/height100/2020/04/02/53dad354-74af-11ea-aae0-02b7b76bf47f.png" tvg-name="StuBru #ikluisterbelgisch",StuBru #ikluisterbelgisch
+http://icecast.vrtcdn.be/stubru_tgs-high.mp3?ext=.pvr
+
+#EXTINF:-1 radio="true" tvg-id="mnm" tvg-logo="https://images.vrt.be/height100/logo/mnm/logo_witte_achtergrond.png" tvg-name="MNM",MNM
+http://icecast.vrtcdn.be/mnm-high.mp3?ext=.pvr
+
+#EXTINF:-1 radio="true" tvg-id="mnm-backtothe90sand00s" tvg-logo="https://images.vrt.be/height100/2019/02/21/76e54cd8-35f1-11e9-abcc-02b7b76bf47f.png" tvg-name="MNM Back to the 90's & 00's",MNM Back to the 90's & 00's
+http://icecast.vrtcdn.be/mnm_90s00s-high.mp3?ext=.pvr
+
+#EXTINF:-1 radio="true" tvg-id="mnm-hits" tvg-logo="https://images.vrt.be/orig/logo/mnm/mnm_hits_logo_2018.png" tvg-name="MNM Hits",MNM Hits
+http://icecast.vrtcdn.be/mnm_hits-high.mp3?ext=.pvr
+
+#EXTINF:-1 radio="true" tvg-id="mnm-urbanice" tvg-logo="https://images.vrt.be/height100/logo/mnm_urbanice_logo.png" tvg-name="MNM UrbaNice",MNM UrbaNice
+http://icecast.vrtcdn.be/mnm_urb-high.mp3?ext=.pvr
+
+#EXTINF:-1 radio="true" tvg-id="ketnet-hits" tvg-logo="https://images.vrt.be/height100/logo/ketnet/ketnet_hits_rgb.png" tvg-name="Ketnet Hits",Ketnet Hits
+http://icecast.vrtcdn.be/ketnetradio-high.mp3?ext=.pvr
+
+#EXTINF:-1 radio="true" tvg-id="vrtnws-radio" tvg-logo="https://images.vrt.be/height100/logos/vrtnws.png" tvg-name="VRT NWS",VRT NWS
+https://progressive-audio.lwc.vrtcdn.be/content/fixed/11_11niws-snip_hi.mp3?ext=.pvr
+
+#EXTINF:-1 radio="true" tvg-id="vrt-events-radio" tvg-logo="https://images.vrt.be/orig/logo/vrt.png" tvg-name="VRT Events",VRT Events
+http://icecast.vrtcdn.be/vrtevent-high.mp3?ext=.pvr


### PR DESCRIPTION
This is basic support for PVR IPTV Simple support in Kodi. It is a poor
man's implementation that (as it is) only adds VRT support (both TV and
Radio) to Kodi.

A better alternative is to use IPTV Manager in the future, nevertheless
this may be useful to some already as-is.