### PR TITLE
Switch from mp3_128 to aac_128

### DIFF
--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -37,7 +37,7 @@ def main_menu(path=''):
         icon = icon_path % channel
         thumb = thumb_path % channel
         # url = plugin.url_for(play, name=channel.get('name'))
-        url = channel.get('mp3_128')
+        url = channel.get('aac_128')
 
         item = ListItem(
             label=channel.get('label'),


### PR DESCRIPTION
Since AAC offers better sound quality and it now also includes track
information, there is no reason for not making this the default.